### PR TITLE
Mere support for climateData API

### DIFF
--- a/dmi_open_data/client.py
+++ b/dmi_open_data/client.py
@@ -11,15 +11,18 @@ from dmi_open_data.utils import distance
 class DMIOpenDataClient:
     _base_url = "https://dmigw.govcloud.dk/{version}/{api}"
 
-    def __init__(self, api_key: str, version: str = "v2"):
+    def __init__(self, api_key: str, api_name:str = "metObs", version: str = "v2"):
         if api_key is None:
             raise ValueError(f"Invalid value for `api_key`: {api_key}")
+        if api_name not in ("climateData", "metObs"):
+            raise NotImplementedError(f"Following api is not supported yet: {api_name}")
         if version == "v1":
             raise ValueError(f"DMI metObs v1 not longer supported")
         if version not in ["v2"]:
             raise ValueError(f"API version {version} not supported")
 
         self.api_key = api_key
+        self.api_name = api_name
         self.version = version
 
     def base_url(self, api: str):
@@ -47,8 +50,7 @@ class DMIOpenDataClient:
         return res.json()
 
     def get_stations(
-            self, limit: Optional[int] = 10000, offset: Optional[int] = 0,
-            api: str = "metObs"
+            self, limit: Optional[int] = 10000, offset: Optional[int] = 0
     ) -> List[Dict[str, Any]]:
         """Get DMI stations.
 
@@ -62,7 +64,7 @@ class DMIOpenDataClient:
             List[Dict[str, Any]]: List of DMI stations.
         """
         res = self._query(
-            api=api,
+            api=self.api_name,
             service="collections/station/items",
             params={
                 "limit": limit,

--- a/dmi_open_data/client.py
+++ b/dmi_open_data/client.py
@@ -193,8 +193,8 @@ class DMIOpenDataClient:
         return Parameter(parameter_id)
 
     def get_closest_station(
-            self, latitude: float, longitude: float,
-            pars = []
+        self, latitude: float, longitude: float,
+        pars: List[str] = []
     ) -> List[Dict[str, Any]]:
         """Get closest weather station from given coordinates.
 

--- a/dmi_open_data/client.py
+++ b/dmi_open_data/client.py
@@ -193,7 +193,8 @@ class DMIOpenDataClient:
         return Parameter(parameter_id)
 
     def get_closest_station(
-        self, latitude: float, longitude: float
+            self, latitude: float, longitude: float,
+            pars = []
     ) -> List[Dict[str, Any]]:
         """Get closest weather station from given coordinates.
 
@@ -206,6 +207,7 @@ class DMIOpenDataClient:
         """
         stations = self.get_stations()
         closest_station, closests_dist = None, 1e10
+        want_pars = set (pars)
         for station in stations:
             coordinates = station.get("geometry", {}).get("coordinates")
             if coordinates is None or len(coordinates) < 2:
@@ -214,6 +216,10 @@ class DMIOpenDataClient:
             if lat is None or lon is None:
                 continue
 
+            has_pars = set (station['properties']['parameterId'])
+            if (not want_pars.issubset (has_pars)):
+                continue
+            
             # Calculate distance
             dist = distance(
                 lat1=latitude,

--- a/dmi_open_data/client.py
+++ b/dmi_open_data/client.py
@@ -50,7 +50,7 @@ class DMIOpenDataClient:
         return res.json()
 
     def get_stations(
-            self, limit: Optional[int] = 10000, offset: Optional[int] = 0
+        self, limit: Optional[int] = 10000, offset: Optional[int] = 0
     ) -> List[Dict[str, Any]]:
         """Get DMI stations.
 

--- a/dmi_open_data/client.py
+++ b/dmi_open_data/client.py
@@ -216,7 +216,7 @@ class DMIOpenDataClient:
             if lat is None or lon is None:
                 continue
 
-            has_pars = set (station['properties']['parameterId'])
+            has_pars = set(station["properties"]["parameterId"])
             if (not want_pars.issubset(has_pars)):
                 continue
             

--- a/dmi_open_data/client.py
+++ b/dmi_open_data/client.py
@@ -47,7 +47,8 @@ class DMIOpenDataClient:
         return res.json()
 
     def get_stations(
-        self, limit: Optional[int] = 10000, offset: Optional[int] = 0
+            self, limit: Optional[int] = 10000, offset: Optional[int] = 0,
+            api: str = "metObs"
     ) -> List[Dict[str, Any]]:
         """Get DMI stations.
 
@@ -61,7 +62,7 @@ class DMIOpenDataClient:
             List[Dict[str, Any]]: List of DMI stations.
         """
         res = self._query(
-            api="metObs",
+            api=api,
             service="collections/station/items",
             params={
                 "limit": limit,

--- a/dmi_open_data/client.py
+++ b/dmi_open_data/client.py
@@ -217,7 +217,7 @@ class DMIOpenDataClient:
                 continue
 
             has_pars = set (station['properties']['parameterId'])
-            if (not want_pars.issubset (has_pars)):
+            if (not want_pars.issubset(has_pars)):
                 continue
             
             # Calculate distance

--- a/dmi_open_data/client.py
+++ b/dmi_open_data/client.py
@@ -207,7 +207,7 @@ class DMIOpenDataClient:
         """
         stations = self.get_stations()
         closest_station, closests_dist = None, 1e10
-        want_pars = set (pars)
+        want_pars = set(pars)
         for station in stations:
             coordinates = station.get("geometry", {}).get("coordinates")
             if coordinates is None or len(coordinates) < 2:

--- a/dmi_open_data/enums.py
+++ b/dmi_open_data/enums.py
@@ -85,6 +85,7 @@ class ClimateDataParameter(Enum):
     MaxPressure = "max_pressure"
     MinPressure = "min_pressure"
     BrightSunshine = "bright_sunshine"
+    MeanRadiation = "mean_radiation"
     AccPrecip = "acc_precip"
     MaxPrecip_24h = "max_precip_24h"
     AccPrecipPast12h = "acc_precip_past12h"


### PR DESCRIPTION
Hej Lasse.

Tak for et nyttigt stykke kode.

Jeg prøvede at kalde get_stations med en client åbnet med en "climateData"api key, det virkede ikke da get_stations er hardkodet til "metObs" api.  Jeg tror ikke man kan blande api key og api, så måske giver det mest mening at gemme navnet på api'en sammen med key i client datastrukturen?

Mvh,

Per