### PR TITLE
amend get_parameter doc-string

### DIFF
--- a/dmi_open_data/client.py
+++ b/dmi_open_data/client.py
@@ -182,7 +182,7 @@ class DMIOpenDataClient:
         """Get parameter enum from DMI parameter id.
 
         Args:
-            parameter_id (int): Parameter id found on DMI API documentation.
+            parameter_id (str): Parameter id found on DMI API documentation.
 
         Returns:
             Parameter: Parameter enum object.


### PR DESCRIPTION
Hi Lasse,

Thanks for this awesome library. 

I've been playing around with your library and it's great!

However, I've found a small error in the doc-string for `get_parameter`. It says the parameter is expected to be of type `int` but it should be of type `str`. The type annotation for the parameter in the function is correct, it's only the doc string that is disagreeable.

For good measure allow me to explain myself;

Changing the doc-string type annotation for `parameter_id` to type `str` would agree with both DMI's documentation and the functions own logic, where we get a `Parameter` from the enum object, given a value. However, since all values are of type `str` in the `Parameter` enum, it would never work with type `int` (it would raise a `ValueError`).

Minor thing but thought I'd give a shout.

Anyways, all the best and thanks again for your work. Good stuff.

Christian