### PR TITLE
Remove auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ from dmi_open_data import DMIOpenDataClient, Parameter, ClimateDataParameter, Oc
 
 
 # Get 10 stations
-client = DMIOpenDataClient(api_key=os.getenv('DMI_API_KEY'))
+client = DMIOpenDataClient()
 stations = client.get_stations(limit=10)
 
 # Get all stations
@@ -56,7 +56,7 @@ observations = client.get_observations(
     limit=1000)
 
 # Init climate data client
-climate_data_client = DMIOpenDataClient(api_key=os.getenv('DMI_CLIMATE_DATA_API_KEY'))
+climate_data_client = DMIOpenDataClient()
 
 # Get climate data
 climate_data = climate_data_client.get_climate_data(
@@ -68,7 +68,7 @@ climate_data = climate_data_client.get_climate_data(
     limit=1000)
 
 # Init oceanographic data client
-ocean_data_client = DMIOpenDataClient(api_key=os.getenv('DMI_OCEAN_DATA_API_KEY'))
+ocean_data_client = DMIOpenDataClient()
 
 # Get oceanographic data
 ocean_data = ocean_data_client.get_ocean_data(

--- a/README.md
+++ b/README.md
@@ -79,10 +79,6 @@ ocean_data = ocean_data_client.get_ocean_data(
     limit=1000)
 ```
 
-## API Key
-
-API Key can be obtained for free at the [DMI Open Data](https://confluence.govcloud.dk/pages/viewpage.action?pageId=26476690).
-
 ## Tests
 
 Run tests

--- a/dmi_open_data/client.py
+++ b/dmi_open_data/client.py
@@ -13,17 +13,14 @@ from dmi_open_data.utils import distance
 
 
 class DMIOpenDataClient:
-    _base_url = "https://dmigw.govcloud.dk/{version}/{api}"
+    _base_url = "https://opendataapi.dmi.dk/{version}/{api}"
 
-    def __init__(self, api_key: str, version: str = "v2"):
-        if api_key is None:
-            raise ValueError(f"Invalid value for `api_key`: {api_key}")
+    def __init__(self, version: str = "v2"):
         if version == "v1":
             raise ValueError(f"DMI metObs v1 not longer supported")
         if version not in ["v2"]:
             raise ValueError(f"API version {version} not supported")
 
-        self.api_key = api_key
         self.version = version
 
     def base_url(self, api: str):
@@ -36,7 +33,6 @@ class DMIOpenDataClient:
         res = requests.get(
             url=f"{self.base_url(api=api)}/{service}",
             params={
-                "api-key": self.api_key,
                 **params,
             },
             **kwargs,

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -8,7 +8,7 @@ from dmi_open_data import DMIOpenDataClient, Parameter, microseconds2date
 class TestClient(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.client = DMIOpenDataClient(api_key=os.getenv("DMI_API_KEY"))
+        cls.client = DMIOpenDataClient()
 
     def test_stations(self):
         stations = self.client.get_stations()

--- a/tests/test_climate_data_client.py
+++ b/tests/test_climate_data_client.py
@@ -8,12 +8,12 @@ from dmi_open_data import DMIOpenDataClient, ClimateDataParameter
 class TestClient(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.client = DMIOpenDataClient(api_key=os.getenv("DMI_CLIMATE_DATA_API_KEY"))
+        cls.client = DMIOpenDataClient()
 
     def test_observations(self):
         climate_data = self.client.get_climate_data(
             parameter=ClimateDataParameter.MeanTemp,
-            station_id="06184",
+            station_id="06180",
             from_time=datetime(2021, 7, 20),
             to_time=datetime(2021, 7, 24),
             time_resolution="day",


### PR DESCRIPTION
DMI har 2.12.2025 fjernet brugen af API nøgler for at tilgå data.
https://www.dmi.dk/friedata/dokumentation/authentication

Har rettet base_url og fjernet API nøgle parameter.
Test af klient klasse tilpasset.